### PR TITLE
Add font-awesome.css

### DIFF
--- a/MMM-SystemStats.js
+++ b/MMM-SystemStats.js
@@ -19,7 +19,10 @@ Module.register('MMM-SystemStats', {
     baseURLSyslog: 'http://127.0.0.1:8080/syslog',
     label: 'textAndIcon'
   },
-
+  // Define required styles.
+  getStyles: function() {
+    return ["font-awesome.css"];
+  },
   // Define required scripts.
 	getScripts: function () {
       return ["moment.js", "moment-duration-format.js"];

--- a/MMM-SystemStats.js
+++ b/MMM-SystemStats.js
@@ -118,7 +118,7 @@ Module.register('MMM-SystemStats', {
 
       if (self.config.label.match(/^(icon|textAndIcon)$/)) {
         var c2 = document.createElement('td');
-        c2.innerHTML = `<i class="fa ${sysData[item].icon}" style="margin-right: 4px;"></i>`;
+        c2.innerHTML = `<i class="fa ${sysData[item].icon} fa-fw"></i>`;
         row.appendChild(c2);
       }
 


### PR DESCRIPTION
If MMM-SystemStats is the only module included in `config.js`, or the other modules included in the `config.js` file do not require the font-awesome icons, no icons will be display next to the stats in this module.

To reproduce the issue, remove all modules from `config.js` except `MMM-SystemStats` and restart the mirror - no icons will be displayed.

To fix, include the getStyles method referencing font awesome and run the mirror with the same config (i.e. only the MMM-SystemStats module) - the icons should be displayed

For details see the [MagicMirror² Module Development Documentation](https://github.com/MichMich/MagicMirror/tree/develop/modules#getstyles)

