### PR TITLE
Update MMM-SystemStats.js

### DIFF
--- a/MMM-SystemStats.js
+++ b/MMM-SystemStats.js
@@ -60,6 +60,8 @@ Module.register('MMM-SystemStats', {
     //Log.log(payload);
     if (notification === 'STATS') {
       this.stats.cpuTemp = payload.cpuTemp;
+      // remove plus sign from the beginning
+      this.stats.cpuTemp = this.stats.cpuTemp.replace(/^\+/, "");
       //console.log("this.config.useSyslog-" + this.config.useSyslog + ', this.stats.cpuTemp-'+parseInt(this.stats.cpuTemp)+', this.config.thresholdCPUTemp-'+this.config.thresholdCPUTemp);
       if (this.config.useSyslog) {
         var cpuTemp = Math.ceil(parseFloat(this.stats.cpuTemp));


### PR DESCRIPTION
Operating on an Intel Mac, Linux reports the temperature with a preceding '+' that is undesirable.